### PR TITLE
Adding Support for Credentials via env()

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ return [
     */
  
     'application_credentials' => env('GOOGLE_CLOUD_APPLICATION_CREDENTIALS'),
+
+
+    /*
+    | OPTIONAL: 
+    | Use keyFile to use a json config from the current environment.
+    | For example secrets in laravel vapor
+    |
+    | https://docs.vapor.build/1.0/projects/environments.html#secrets
+    */
+    //'keyFile' => json_decode(env('GOOGLE_CLOUD_APPLICATION_CREDENTIALS'), true),
  
     /*
     |--------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ return [
     |
     | https://docs.vapor.build/1.0/projects/environments.html#secrets
     */
-    //'keyFile' => json_decode(env('GOOGLE_CLOUD_APPLICATION_CREDENTIALS'), true),
+    //'keyFile' => json_decode(trim(env('GOOGLE_CLOUD_APPLICATION_CREDENTIALS')), true),
  
     /*
     |--------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ return [
 
 
     /*
-    | OPTIONAL: 
+    | OPTIONAL:
     | Use keyFile to use a json config from the current environment.
     | For example secrets in laravel vapor
     |

--- a/src/BigQueryClientFactory.php
+++ b/src/BigQueryClientFactory.php
@@ -14,6 +14,7 @@ class BigQueryClientFactory
         $clientConfig = array_merge([
             'projectId' => $bigQueryConfig['project_id'],
             'keyFilePath' => $bigQueryConfig['application_credentials'],
+            'keyFile' => Arr::get($bigQueryConfig, 'keyFile', null),
             'authCache' => self::configureCache($bigQueryConfig['auth_cache_store']),
         ], Arr::get($bigQueryConfig, 'client_options', []));
 

--- a/src/BigQueryServiceProvider.php
+++ b/src/BigQueryServiceProvider.php
@@ -42,7 +42,7 @@ class BigQueryServiceProvider extends ServiceProvider
 
     protected function guardAgainstInvalidConfiguration(array $bigQueryConfig = null)
     {
-        if (! file_exists($bigQueryConfig['application_credentials']) && !array_key_exists('keyFile', $bigQueryConfig)) {
+        if (! file_exists($bigQueryConfig['application_credentials']) && ! array_key_exists('keyFile', $bigQueryConfig)) {
             throw InvalidConfiguration::credentialsJsonDoesNotExist($bigQueryConfig['application_credentials']);
         }
     }

--- a/src/BigQueryServiceProvider.php
+++ b/src/BigQueryServiceProvider.php
@@ -42,7 +42,7 @@ class BigQueryServiceProvider extends ServiceProvider
 
     protected function guardAgainstInvalidConfiguration(array $bigQueryConfig = null)
     {
-        if (! file_exists($bigQueryConfig['application_credentials'])) {
+        if (! file_exists($bigQueryConfig['application_credentials']) && !array_key_exists('keyFile', $bigQueryConfig)) {
             throw InvalidConfiguration::credentialsJsonDoesNotExist($bigQueryConfig['application_credentials']);
         }
     }

--- a/src/config/bigquery.php
+++ b/src/config/bigquery.php
@@ -16,6 +16,15 @@ return [
     'application_credentials' => env('GOOGLE_CLOUD_APPLICATION_CREDENTIALS'),
 
     /*
+    | OPTIONAL: 
+    | Use keyFile to use a json config from the current environment.
+    | For example secrets in laravel vapor
+    |
+    | https://docs.vapor.build/1.0/projects/environments.html#secrets
+    */
+    //'keyFile' => json_decode(env('GOOGLE_CLOUD_APPLICATION_CREDENTIALS'), true),
+
+    /*
     |--------------------------------------------------------------------------
     | Project ID
     |--------------------------------------------------------------------------

--- a/src/config/bigquery.php
+++ b/src/config/bigquery.php
@@ -22,7 +22,7 @@ return [
     |
     | https://docs.vapor.build/1.0/projects/environments.html#secrets
     */
-    //'keyFile' => json_decode(env('GOOGLE_CLOUD_APPLICATION_CREDENTIALS'), true),
+    //'keyFile' => json_decode(trim(env('GOOGLE_CLOUD_APPLICATION_CREDENTIALS')), true),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/config/bigquery.php
+++ b/src/config/bigquery.php
@@ -16,7 +16,7 @@ return [
     'application_credentials' => env('GOOGLE_CLOUD_APPLICATION_CREDENTIALS'),
 
     /*
-    | OPTIONAL: 
+    | OPTIONAL:
     | Use keyFile to use a json config from the current environment.
     | For example secrets in laravel vapor
     |


### PR DESCRIPTION
With this change you are now able to define a env value that represents valid json. Helpful in serverless environments like vapor. 