### PR TITLE
Add locale to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ return [
     'client_options' => [
         'retries' => 3, // Default
     ],
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Dataset location
+    |--------------------------------------------------------------------------
+    |
+    | Specify the dataset location.
+    |
+    | Supported values can be found at https://cloud.google.com/bigquery/docs/locations
+    |
+    */
+
+    'location' => '',
 ];
 ```
 

--- a/src/BigQueryClientFactory.php
+++ b/src/BigQueryClientFactory.php
@@ -16,6 +16,7 @@ class BigQueryClientFactory
             'keyFilePath' => $bigQueryConfig['application_credentials'],
             'keyFile' => Arr::get($bigQueryConfig, 'keyFile', null),
             'authCache' => self::configureCache($bigQueryConfig['auth_cache_store']),
+            'location' => Arr::get($bigQueryConfig, 'location', null),
         ], Arr::get($bigQueryConfig, 'client_options', []));
 
         return new BigQueryClient($clientConfig);

--- a/src/config/bigquery.php
+++ b/src/config/bigquery.php
@@ -63,4 +63,17 @@ return [
     'client_options' => [
         'retries' => 3, // Default
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Dataset location
+    |--------------------------------------------------------------------------
+    |
+    | Specify the dataset location.
+    |
+    | Supported values can be found at https://cloud.google.com/bigquery/docs/locations
+    |
+    */
+
+    'location' => '',
 ];


### PR DESCRIPTION
New datasets are created - by default - in the US region. We add the location option in the configuration, to set the region you would like to use, i.e. EU.